### PR TITLE
Adding Gofmt and refreshing updating script 

### DIFF
--- a/client-side/pre-commit
+++ b/client-side/pre-commit
@@ -5,37 +5,8 @@
 # If not, commit will fail with an error message
 #
 # File should be .git/hooks/pre-commit and executable
-FILES_PATTERN='.*vault.*\.yml$'
-REQUIRED='ANSIBLE_VAULT'
 
-EXIT_STATUS=0
-wipe="\e[1m\033[0m"
-yellow='\e[1;33m'
-# carriage return hack. Leave it on 2 lines.
-cr='
-'
-for f in $(git diff --cached --name-only | grep -E $FILES_PATTERN)
-do
-  # test for the presence of the required bit.
-  MATCH=`head -n1 $f | grep --no-messages $REQUIRED`
-  if [ ! $MATCH ] ; then
-    # Build the list of unencrypted files if any
-    UNENCRYPTED_FILES="$f$cr$UNENCRYPTED_FILES"
-    EXIT_STATUS=1
-  fi
+for hook in .git/hooks/pre-commit.d/*; do
+	test -x ${hook}
+	(echo "${data}" | ${hook}) || exit
 done
-if [ ! $EXIT_STATUS = 0 ] ; then
-  echo '# COMMIT REJECTED'
-  echo '# Looks like unencrypted ansible-vault files are part of the commit:'
-  echo '#'
-  while read -r line; do
-    if [ -n "$line" ]; then
-      echo -e "#\t${yellow}unencrypted:   $line${wipe}"
-    fi
-  done <<< "$UNENCRYPTED_FILES"
-  echo '#'
-  echo "# Please encrypt them with 'ansible-vault encrypt <file>'"
-  echo "#   (or force the commit with '--no-verify')."
-  exit $EXIT_STATUS
-fi
-exit $EXIT_STATUS

--- a/client-side/pre-commit.d/pre-commit-ansible-vault
+++ b/client-side/pre-commit.d/pre-commit-ansible-vault
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Pre-commit hook that verifies if all files containing 'vault' in the name
+# are encrypted.
+# If not, commit will fail with an error message
+#
+# File should be .git/hooks/pre-commit and executable
+FILES_PATTERN='.*vault.*\.yml$'
+REQUIRED='ANSIBLE_VAULT'
+
+EXIT_STATUS=0
+wipe="\e[1m\033[0m"
+yellow='\e[1;33m'
+# carriage return hack. Leave it on 2 lines.
+cr='
+'
+for f in $(git diff --cached --name-only | grep -E $FILES_PATTERN)
+do
+  # test for the presence of the required bit.
+  MATCH=`head -n1 $f | grep --no-messages $REQUIRED`
+  if [ ! $MATCH ] ; then
+    # Build the list of unencrypted files if any
+    UNENCRYPTED_FILES="$f$cr$UNENCRYPTED_FILES"
+    EXIT_STATUS=1
+  fi
+done
+if [ ! $EXIT_STATUS = 0 ] ; then
+  echo '# COMMIT REJECTED'
+  echo '# Looks like unencrypted ansible-vault files are part of the commit:'
+  echo '#'
+  while read -r line; do
+    if [ -n "$line" ]; then
+      echo -e "#\t${yellow}unencrypted:   $line${wipe}"
+    fi
+  done <<< "$UNENCRYPTED_FILES"
+  echo '#'
+  echo "# Please encrypt them with 'ansible-vault encrypt <file>'"
+  echo "#   (or force the commit with '--no-verify')."
+  exit $EXIT_STATUS
+fi
+exit $EXIT_STATUS

--- a/client-side/pre-commit.d/pre-commit-gofmt
+++ b/client-side/pre-commit.d/pre-commit-gofmt
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copyright 2012 The Go Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# git gofmt pre-commit hook
+#
+# To use, store as .git/hooks/pre-commit inside your repository and make sure
+# it has execute permissions.
+#
+# This script does not handle file names that contain spaces.
+
+gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
+[ -z "$gofiles" ] && exit 0
+
+unformatted=$(gofmt -l $gofiles)
+[ -z "$unformatted" ] && exit 0
+
+# Some files are not gofmt'd. Print message and fail.
+
+echo >&2 "Go files must be formatted with gofmt. Please run:"
+for fn in $unformatted; do
+	echo >&2 "  gofmt -w $PWD/$fn"
+done
+
+exit 1


### PR DESCRIPTION
The gofmt hook has been added, it forces you to run go fmt before commiting, because it cannot modify the files for you before you commit. The update_script has also been updated because some hooks are now in a folder (pre-commit.d) and being called by the 'pre-commit' hook.