### PR TITLE
pre-push: fix git log command when branch has dashes

### DIFF
--- a/client-side/pre-push
+++ b/client-side/pre-push
@@ -9,7 +9,7 @@
 #
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-UNPUSHED_COMMITS=$(git log origin/${BRANCH}..HEAD --pretty=format:"%h")
+UNPUSHED_COMMITS=$(git log --pretty=format:"%h" -- "origin/${BRANCH}..HEAD")
 FILES_PATTERN='.*vault.*\.yml$'
 REQUIRED='ANSIBLE_VAULT'
 


### PR DESCRIPTION
If the branches had dashes in their name that would trigger some weird
behaviour, as it would be interepreted as an argument or such.

Fixes: https://github.com/cycloidio/cycloid-hooks/issues