### PR TITLE
Pre-push checks concourse-variables files

### DIFF
--- a/client-side/pre-push
+++ b/client-side/pre-push
@@ -10,7 +10,7 @@
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 UNPUSHED_COMMITS=$(git log origin/${BRANCH}..HEAD --pretty=format:"%h")
-FILES_PATTERN='.*vault.*\.yml$'
+FILES_PATTERN='.*concourse-variables|vault.*\.yml$'
 REQUIRED='ANSIBLE_VAULT'
 
 EXIT_STATUS=0


### PR DESCRIPTION
It should close #7

Update client side pre-push hook to check unencrypted data on files whose name contains concourse-variables