### PR TITLE
pre-commit: update gofmt hooks to use goimports

### DIFF
--- a/client-side/pre-commit.d/pre-commit-goimports
+++ b/client-side/pre-commit.d/pre-commit-goimports
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# git gofmt pre-commit hook
+# git goimports pre-commit hook
 #
 # To use, store as .git/hooks/pre-commit inside your repository and make sure
 # it has execute permissions.
@@ -13,14 +13,14 @@
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
 [ -z "$gofiles" ] && exit 0
 
-unformatted=$(gofmt -l $gofiles)
+unformatted=$(goimports -l $gofiles)
 [ -z "$unformatted" ] && exit 0
 
-# Some files are not gofmt'd. Print message and fail.
+# Some files are not goimports'd. Print message and fail.
 
-echo >&2 "Go files must be formatted with gofmt. Please run:"
+echo >&2 "Go files must be formatted with goimports. Please run:"
 for fn in $unformatted; do
-	echo >&2 "  gofmt -w $PWD/$fn"
+	echo >&2 "  goimports -w $PWD/$fn"
 done
 
 exit 1


### PR DESCRIPTION
As mentioned on github go imports provide a better formating than go
fmt, while still having the same advantages, so it makes sense to use
this one rather than go fmt.

Closes: https://github.com/cycloidio/cycloid-hooks/issues