### PR TITLE
pre-commit-goimports: Ignore files in vendor dir

### DIFF
--- a/client-side/pre-commit.d/pre-commit-goimports
+++ b/client-side/pre-commit.d/pre-commit-goimports
@@ -10,7 +10,7 @@
 #
 # This script does not handle file names that contain spaces.
 
-gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
+gofiles=$(git diff --cached --name-only --diff-filter=ACM | awk '/.go$/ && !/vendor\//')
 [ -z "$gofiles" ] && exit 0
 
 unformatted=$(goimports -l $gofiles)


### PR DESCRIPTION
Update goimports pre-commit hook in order to ignore the files inside of
vendor directory