### PR TITLE
client-side: Use sh instead of bash and call perl with env

### DIFF
--- a/client-side/commit-msg
+++ b/client-side/commit-msg
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # This hook checks the syntax of git commit messages before they are commited.
 #

--- a/client-side/pre-commit
+++ b/client-side/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Pre-commit hook that verifies if all files containing 'vault' in the name
 # are encrypted.

--- a/client-side/pre-commit.d/pre-commit-ansible-vault
+++ b/client-side/pre-commit.d/pre-commit-ansible-vault
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Pre-commit hook that verifies if all files containing 'vault' in the name
 # are encrypted.

--- a/client-side/pre-push
+++ b/client-side/pre-push
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Pre-push hook that verifies if all files containing 'vault' in the name
 # are encrypted. If not, push will fail with an error message

--- a/scripts/update_hook.sh
+++ b/scripts/update_hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # This script updates all hooks located in the TEMPLATE_HOOK_DIR of all repositories located under the GIT_DIR.
 # This allows to easily update hooks to use their latest version.


### PR DESCRIPTION
I have switched to NixOS, which is a special Linux distribution. Among other things, this operating system does not have the usual POSIX directory tree. In particular, there is no /bin/bash and no /usr/bin/perl.

So:
* after reading the shell scripts, it looks like they are not using anything specific to bash, se we can call /bin/sh
* we can call perl with /usr/bin/env, like we do with python